### PR TITLE
Optionally, use multiprocessing instead of gevent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,11 @@ Set the amount of workers to 30::
     python manage.py collectstatic --faster --workers=30
 
 
+Spawn workers using ``multiprocessing`` instead of ``gevent``::
+
+    python manage.py collectstatic --faster --use-multiprocessing
+
+
 Credits
 -------
 


### PR DESCRIPTION
I discovered that when trying to use `django-collectfaster` with `django-storages` and a `boto3` backend (NB: not plain old `boto` but [`boto3`](https://boto3.readthedocs.io/en/latest/)) that the first few files are copied successfully, followed by the remainder of them complaining about:

    LoopExit: ('This operation would block forever', <Hub at 0x... select pending=0 ref=0>)
    Wed Mar 29 18:21:28 2017 <Greenlet at 0x...: <bound method Command.gevent_worker of <collectfaster.management.commands.collectstatic.Command object at 0x...>>> failed with LoopExit

It seems as though [`boto3` uses threads to do multi-part transfers by default](http://boto3.readthedocs.io/en/latest/guide/upgrading.html?highlight=use_threads) and this conflicts with the gevent workers in some way.

FWIW, `django-storages` presently [recommends using their `boto3` backend over the older `boto`-based backend](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#usage)

Thoughts/feelings?